### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # django-typograf
 [![Build Status](https://travis-ci.org/Samael500/django-typograf.svg)](https://travis-ci.org/Samael500/django-typograf)
-[![Latest Version](https://pypip.in/version/django-typograf/badge.svg)](https://pypi.python.org/pypi/django-typograf/)
+[![Latest Version](https://img.shields.io/pypi/v/django-typograf.svg)](https://pypi.python.org/pypi/django-typograf/)
 
 Django app for typograf models.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-typograf))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-typograf`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.